### PR TITLE
Edited the tabs in header

### DIFF
--- a/_data/en.yml
+++ b/_data/en.yml
@@ -2,6 +2,8 @@
 whatWeDo: Computational Biology, Ecology, & Evolution 
 contact: Contact
 tellMeMore: Tell Me More
+rsg: R Study Group
+psg: Python Study Group
 
 activitiesSubheading: 'ComBEE is a group of researchers at UW-Madison interested in computational biology in ecology and evolution.'
 activities:

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,10 +19,10 @@
                         <a href="#page-top"></a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="#services">{{site.data[site.language].whatWeDo}}</a>
+                        <a href="https://github.com/ComBEE-UW-Madison/RStudyGroup">{{site.data[site.language].rsg}}</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="#portfolio">{{site.data[site.language].events}}</a>
+                        <a href="https://github.com/ComBEE-UW-Madison/PythonStudyGroup">{{site.data[site.language].psg}}</a>
                     </li>
                     <li>
                         <a class="page-scroll" href="#contact">{{site.data[site.language].contact}}</a>


### PR DESCRIPTION
Now only includes rsg, psg, and join listserv.

I also added data tags that you can reference the words Rstudy group and python study group with.

e.g.
{{site.data[site.language].psg}} is really awesome!